### PR TITLE
[Feature] Both exclude license info and exclude missing license files can be found on a custom Maven Artifact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ mvn clean install
 
 You have now installed the snapshot-version.
 
+# Adding license info on a Maven Artifact
+Sometimes, to use the same files for many projects or to separate Maven build files from code files, do you want to put the files on other project and import it during the build. 
+It is possible to do this with license info and allowed missing licenses files.
+In order to do this, you need to add to your plugin configuration a dependency section with the artifact containing the files, like this : 
+
+```
+                    <dependency>
+                        <groupId>com.mycompany</groupId>
+                        <artifactId>AyoyLicenseManagement</artifactId>
+                        <version>1.0.0</version>  
+                    </dependency> 
+```
+Then, the project containing the files should : 
+1. Be packaged as a jar
+2. Contain on folder src/main/resources/se/ayoy/maven/plugins/licenseverifier the license and exclusion files
+
+On demo module, the project child2 performs an analysis using the files of the project LicenseManagement. 
+
 # Running tests
 
 Run a single integration test like this:

--- a/demo/LicensesProject/pom.xml
+++ b/demo/LicensesProject/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>se.ayoy.maven-plugins.demo</groupId>
+    <artifactId>LicensesProject</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>se.ayoy.maven-plugins.demo</groupId>
+        <artifactId>demo-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <name>LicensesProject</name>
+    <description>A demo of multi module maven project with Ayoy-Maven-License-Verifier-Plugin.</description>
+    <url>https://github.com/AyoyAB/Ayoy-Maven-License-Verifier-Plugin/tree/master/demo</url>
+
+    <inceptionYear>2018</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <minMavenVersion>3.0.5</minMavenVersion>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <developers>
+        <developer>
+            <id>smuda</id>
+            <name>John Allberg</name>
+            <email>john+github@ayoy.se</email>
+            <url>https://www.ayoy.se</url>
+            <organization>Ayoy AB</organization>
+            <organizationUrl>https://www.ayoy.se</organizationUrl>
+        </developer>
+    </developers>
+
+    <dependencies>
+    </dependencies>
+
+
+</project>

--- a/demo/LicensesProject/src/main/resources/se/ayoy/maven/plugins/licenseverifier/allowedMissingLicense.xml
+++ b/demo/LicensesProject/src/main/resources/se/ayoy/maven/plugins/licenseverifier/allowedMissingLicense.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<missing>
+    <dependency>
+        <groupId>com.oracle.weblogic</groupId>
+        <artifactId>wlthint3client</artifactId>
+        <version>12.2.1-2-1</version>
+    </dependency>
+</missing>

--- a/demo/LicensesProject/src/main/resources/se/ayoy/maven/plugins/licenseverifier/licenses.xml
+++ b/demo/LicensesProject/src/main/resources/se/ayoy/maven/plugins/licenseverifier/licenses.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<licenses>
+    <valid>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <names>
+                <name>The Apache Software License, Version 2.0</name>
+            </names>
+            <urls>
+                <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            </urls>
+        </license>
+        <license>
+            <name>Eclipse Public License 1.0</name>
+            <names>
+                <name>Eclipse Public License 1.0</name>
+            </names>
+            <urls>
+                <url>http://www.eclipse.org/legal/epl-v10.html</url>
+            </urls>
+        </license>
+        <license>
+            <name>The MIT License</name>
+            <names>
+                <name>The MIT License</name>
+            </names>
+            <urls>
+                <url>http://code.google.com/p/mockito/wiki/License</url>
+            </urls>
+        </license>
+    </valid>
+    <forbidden>
+        <license>
+            <name>GNU General Public License version 2</name>
+            <names>
+                <name>GNU General Public License version 2</name>
+            </names>
+            <urls>
+                <url>https://opensource.org/licenses/gpl-2.0.php</url>
+            </urls>
+        </license>
+    </forbidden>
+</licenses>

--- a/demo/child2/pom.xml
+++ b/demo/child2/pom.xml
@@ -6,9 +6,16 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>se.ayoy.maven-plugins.demo</groupId>
-    <artifactId>demo-parent</artifactId>
+    <artifactId>child2</artifactId>
     <version>1.0.0</version>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>se.ayoy.maven-plugins.demo</groupId>
+        <artifactId>demo-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A demo of multi module maven project with Ayoy-Maven-License-Verifier-Plugin.</description>
@@ -23,12 +30,6 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-
-    <modules>
-        <module>LicensesProject</module>
-        <module>child1</module>
-        <module>child2</module>
-    </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -51,12 +52,12 @@
     <dependencies>
     </dependencies>
 
-    <build>
+<build>
         <plugins>
             <plugin>
                 <groupId>se.ayoy.maven-plugins</groupId>
                 <artifactId>ayoy-license-verifier-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.1.1-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <phase>compile</phase>
@@ -66,20 +67,19 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <licenseFile>licenses/licenses.xml</licenseFile>
-                    <excludedMissingLicensesFile>licenses/allowedMissingLicense.xml</excludedMissingLicensesFile>
+                    <licenseFile>licenses.xml</licenseFile>
+                    <excludedMissingLicensesFile>allowedMissingLicense.xml</excludedMissingLicensesFile>
                     <failOnForbidden>true</failOnForbidden>
                     <failOnMissing>true</failOnMissing>
                     <failOnUnknown>true</failOnUnknown>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <configLocation>checkstyle.xml</configLocation>
-                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>se.ayoy.maven-plugins.demo</groupId>
+                        <artifactId>LicensesProject</artifactId>
+                        <version>1.0.0</version>  
+                    </dependency>                 
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/demo/child2/src/main/java/se/ayoy/maven/plugins/licenseverifier/demo/child1/Main.java
+++ b/demo/child2/src/main/java/se/ayoy/maven/plugins/licenseverifier/demo/child1/Main.java
@@ -1,0 +1,8 @@
+package se.ayoy.maven.plugins.licenseverifier.demo.child1;
+
+public class Main {
+    public static void main(String[] args) {
+        // Prints "Hello, World" to the terminal window.
+        System.out.println("Hello, World");
+    }
+}

--- a/src/main/java/se/ayoy/maven/plugins/licenseverifier/LicenceFile.java
+++ b/src/main/java/se/ayoy/maven/plugins/licenseverifier/LicenceFile.java
@@ -1,0 +1,40 @@
+package se.ayoy.maven.plugins.licenseverifier;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * Abstract file used for common methods by LicenceInfoFile and ExcludedMissingLicenseFile.
+ */
+public abstract class LicenceFile {
+
+    /**
+     * Either reads a file or reads a resource from a package.
+     * @param file           The file to read.
+     * @param filePathString The path to read.
+     * @return an input stream to read the configuration file.
+     * @throws FileNotFoundException if the file could not be found.
+     */
+    protected InputStream getInputStreamFromFileOrResource(File file, String filePathString)
+            throws FileNotFoundException {
+
+        if (!file.exists()) {
+            // lets try to get it as resource
+            URL url = LicenseVerifierMojo.class.getResource(filePathString);
+            if (url == null) {
+                throw new FileNotFoundException(filePathString);
+            }
+            try {
+                return url.openStream();
+            } catch (IOException ex) {
+                throw new FileNotFoundException(filePathString);
+            }
+        } else {
+            return new FileInputStream(file);
+        }
+    }
+}

--- a/src/main/java/se/ayoy/maven/plugins/licenseverifier/LicenseInfo/LicenseInfoFile.java
+++ b/src/main/java/se/ayoy/maven/plugins/licenseverifier/LicenseInfo/LicenseInfoFile.java
@@ -8,21 +8,20 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException; // catching unsupported features
-import se.ayoy.maven.plugins.licenseverifier.LicenseVerifierMojo;
+
+import se.ayoy.maven.plugins.licenseverifier.LicenceFile;
 
 /**
  * Represents the file in which licenses are categorized.
  */
-public class LicenseInfoFile {
+public class LicenseInfoFile extends LicenceFile {
 
     private ArrayList<LicenseInfo> licenseInfos = new ArrayList<LicenseInfo>();
     private Log log;
@@ -47,21 +46,8 @@ public class LicenseInfoFile {
                         + filePathString);
 
         File file = new File(filePathString);
-        InputStream inputStream;
-        if (!file.exists()) {
-            // lets try to get it as resource
-            URL url = LicenseVerifierMojo.class.getResource(filePathString);
-            if (url == null) {
-                throw new FileNotFoundException(filePathString);
-            }
-            try {
-                inputStream = url.openStream();
-            } catch (IOException ex) {
-                throw new FileNotFoundException(filePathString);
-            }
-        } else {
-            inputStream = new FileInputStream(file);
-        }
+        InputStream inputStream = getInputStreamFromFileOrResource(file, filePathString);
+
         log.debug("Reading file " + filePathString);
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 

--- a/src/main/java/se/ayoy/maven/plugins/licenseverifier/LicenseInfo/LicenseInfoFile.java
+++ b/src/main/java/se/ayoy/maven/plugins/licenseverifier/LicenseInfo/LicenseInfoFile.java
@@ -52,7 +52,6 @@ public class LicenseInfoFile {
             // lets try to get it as resource
             URL url = LicenseVerifierMojo.class.getResource(filePathString);
             if (url == null) {
-                this.log.warn("PATH not found!!!");
                 throw new FileNotFoundException(filePathString);
             }
             try {

--- a/src/main/java/se/ayoy/maven/plugins/licenseverifier/MissingLicenseInfo/ExcludedMissingLicenseFile.java
+++ b/src/main/java/se/ayoy/maven/plugins/licenseverifier/MissingLicenseInfo/ExcludedMissingLicenseFile.java
@@ -7,24 +7,22 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import se.ayoy.maven.plugins.licenseverifier.LicenceFile;
 import se.ayoy.maven.plugins.licenseverifier.model.AyoyArtifact;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.ArrayList;
-import se.ayoy.maven.plugins.licenseverifier.LicenseVerifierMojo;
 
 /**
  * Parses the file for exclusions of missing license information.
  */
-public class ExcludedMissingLicenseFile {
+public class ExcludedMissingLicenseFile extends LicenceFile {
     private ArrayList<ExcludedMissingLicense> missingInfos = new ArrayList<ExcludedMissingLicense>();
     private Log log;
 
@@ -47,21 +45,7 @@ public class ExcludedMissingLicenseFile {
             "Path to file with dependencies to ignore (without licenses) is "
             + filePathString);
         File file = new File(filePathString);
-        InputStream inputStream;
-        if (!file.exists()) {
-            // lets try to get it as resource
-            URL url = LicenseVerifierMojo.class.getResource(filePathString);
-            if (url == null) {
-                throw new FileNotFoundException(filePathString);
-            }
-            try {
-                inputStream = url.openStream();
-            } catch (IOException ex) {
-                throw new FileNotFoundException(filePathString);
-            }
-        } else {
-            inputStream = new FileInputStream(file);
-        }
+        InputStream inputStream = this.getInputStreamFromFileOrResource(file, filePathString);
 
         log.debug("Reading file " + filePathString);
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();

--- a/src/main/java/se/ayoy/maven/plugins/licenseverifier/MissingLicenseInfo/ExcludedMissingLicenseFile.java
+++ b/src/main/java/se/ayoy/maven/plugins/licenseverifier/MissingLicenseInfo/ExcludedMissingLicenseFile.java
@@ -52,7 +52,6 @@ public class ExcludedMissingLicenseFile {
             // lets try to get it as resource
             URL url = LicenseVerifierMojo.class.getResource(filePathString);
             if (url == null) {
-                this.log.warn("PATH not found!!!");
                 throw new FileNotFoundException(filePathString);
             }
             try {

--- a/src/main/java/se/ayoy/maven/plugins/licenseverifier/MissingLicenseInfo/ExcludedMissingLicenseFile.java
+++ b/src/main/java/se/ayoy/maven/plugins/licenseverifier/MissingLicenseInfo/ExcludedMissingLicenseFile.java
@@ -13,9 +13,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.ArrayList;
+import se.ayoy.maven.plugins.licenseverifier.LicenseVerifierMojo;
 
 /**
  * Parses the file for exclusions of missing license information.
@@ -43,8 +47,21 @@ public class ExcludedMissingLicenseFile {
             "Path to file with dependencies to ignore (without licenses) is "
             + filePathString);
         File file = new File(filePathString);
+        InputStream inputStream;
         if (!file.exists()) {
-            throw new FileNotFoundException(filePathString);
+            // lets try to get it as resource
+            URL url = LicenseVerifierMojo.class.getResource(filePathString);
+            if (url == null) {
+                this.log.warn("PATH not found!!!");
+                throw new FileNotFoundException(filePathString);
+            }
+            try {
+                inputStream = url.openStream();
+            } catch (IOException ex) {
+                throw new FileNotFoundException(filePathString);
+            }
+        } else {
+            inputStream = new FileInputStream(file);
         }
 
         log.debug("Reading file " + filePathString);
@@ -62,7 +79,7 @@ public class ExcludedMissingLicenseFile {
             dbf.setExpandEntityReferences(false);
 
             DocumentBuilder builder = dbf.newDocumentBuilder();
-            Document document = builder.parse(file);
+            Document document = builder.parse(inputStream);
 
             parseInfos(document);
 


### PR DESCRIPTION
Another pull request, a feature fixing #9 . Some code can be probably factorize.
Now  both exclude license info and exclude missing license files can be found on a custom Maven Artifact as sugested in #9 (an needed in my company). 
Here is an example of use bundling a maven artifact, for example com.mycompany.AyoyLicenseManagement
```
            <plugin>
                <groupId>se.ayoy.maven-plugins</groupId>
                <artifactId>ayoy-license-verifier-maven-plugin</artifactId>
                <version>1.1.0</version>
                <executions>
                    <execution>
                        <phase>compile</phase>
                        <goals>
                            <goal>verify</goal>
                        </goals>
                    </execution>
                </executions>
                <configuration>
                    <licenseFile>licenses.xml</licenseFile>
                    <excludedMissingLicensesFile>allowedMissingLicense.xml</excludedMissingLicensesFile>
                    <failOnForbidden>true</failOnForbidden>
                    <failOnMissing>false</failOnMissing>
                    <verbose>false</verbose>
                </configuration>
                <dependencies>
                    <dependency>
                        <groupId>com.mycompany</groupId>
                        <artifactId>AyoyLicenseManagement</artifactId>
                        <version>1.0.0</version>  
                    </dependency>                 
                </dependencies>
            </plugin>
```
The artifact added as dependecy should : 

1. Be packaged as a jar
2. Contain on folder src/main/resources/se/ayoy/maven/plugins/licenseverifier the license and exclusion files (here named as licenses and allowedMissingLicense.xml)